### PR TITLE
Set wrong VALKEY_ADDR environment variable

### DIFF
--- a/kubernetes/argocd-application.yaml
+++ b/kubernetes/argocd-application.yaml
@@ -25,6 +25,13 @@ spec:
     targetRevision: 0.37.6
     helm:
       releaseName: my-otel-demo
+      values: |
+        components:
+          cart:
+            enabled: true
+            envOverrides:
+              - name: VALKEY_ADDR
+                value: https://valkey-cart:6379
       valueFiles:
         - values.yaml
   destination:


### PR DESCRIPTION
# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `VALKEY_ADDR` environment variable for `cart` component in `argocd-application.yaml`.
> 
>   - **Configuration**:
>     - Sets `VALKEY_ADDR` environment variable to `https://valkey-cart:6379` for `cart` component in `argocd-application.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=migrateai%2Fopentelemetry-demo&utm_source=github&utm_medium=referral)<sup> for b25519ac44201bf5f2a59a1f4f105700f477095f. You can [customize](https://app.ellipsis.dev/migrateai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->