### PR TITLE
Add performance metrics and error tracking to checkout and product-catalog services

### DIFF
--- a/src/product-catalog/go.mod
+++ b/src/product-catalog/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/newrelic/go-agent/v3 v3.39.0 // indirect
 	github.com/open-feature/flagd-schemas v0.2.9-0.20250127221449-bb763438abc5 // indirect
 	github.com/open-feature/flagd/core v0.11.2 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect


### PR DESCRIPTION
- Introduced OpenTelemetry metrics for performance tracking in the checkout service, including histograms for order processing durations and error counters.
- Added similar metrics to the product-catalog service, tracking durations for product listing, retrieval, and search operations, along with error metrics.
- Removed New Relic integration from product-catalog to streamline monitoring with OpenTelemetry.
- Enhanced metric initialization and recording for better observability and performance insights.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add OpenTelemetry metrics for performance and error tracking to checkout and product-catalog services, removing New Relic from product-catalog.
> 
>   - **Behavior**:
>     - Added OpenTelemetry metrics in `checkout/main.go` for order processing durations and error counts.
>     - Added similar metrics in `product-catalog/main.go` for product listing, retrieval, and search durations, and error counts.
>     - Removed New Relic integration from `product-catalog`.
>   - **Metrics**:
>     - Introduced histograms for operations like `PlaceOrder`, `prepareOrderItemsAndShippingQuoteFromCart`, `chargeCard`, and `shipOrder` in `checkout/main.go`.
>     - Introduced histograms for `ListProducts`, `GetProduct`, and `SearchProducts` in `product-catalog/main.go`.
>     - Added error counters for handled and unhandled errors in both services.
>   - **Misc**:
>     - Enhanced metric initialization and recording for better observability.
>     - Updated `go.mod` in `product-catalog` to remove New Relic dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=migrateai%2Fopentelemetry-demo&utm_source=github&utm_medium=referral)<sup> for 3d19d181e5a8f5190d653cd2e71ede3338c5a9a8. You can [customize](https://app.ellipsis.dev/migrateai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->